### PR TITLE
Cargo.toml: upgrade esp-backtrace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ embedded-graphics = "0.8.1"
 embedded-hal = "1.0.0"
 embedded-hal-bus = "0.3.0"
 esp-alloc = { version = "0.9.0" }
-esp-backtrace = { version = "0.15.1", features = [
+esp-backtrace = { version = "0.18.1", features = [
     "defmt",
     "esp32s3",
     "panic-handler",


### PR DESCRIPTION
This avoids `esp-println` version incompatibility with new projects.