### PR TITLE
examples: add esp_app_desc for esp-hal 1.0/espflash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp-bootloader-esp-idf"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a56964ab5479ac20c9cf76fa3b0d3f2233b20b5d8554e81ef5d65f63c20567"
+dependencies = [
+ "cfg-if",
+ "document-features",
+ "embedded-storage",
+ "esp-config",
+ "esp-hal-procmacros",
+ "esp-metadata-generated",
+ "esp-rom-sys",
+ "jiff",
+ "strum",
+]
+
+[[package]]
 name = "esp-build"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,6 +960,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +1019,7 @@ dependencies = [
  "embedded-hal-bus",
  "esp-alloc",
  "esp-backtrace",
+ "esp-bootloader-esp-idf",
  "esp-hal",
  "fugit",
  "gc9a01-rs",
@@ -1053,6 +1095,15 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "proc-macro-crate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ esp-backtrace = { version = "0.15.1", features = [
     "esp32s3",
     "panic-handler",
 ] }
+esp-bootloader-esp-idf = { version = "0.4.0", features = ["esp32s3"] }
 esp-hal = { version = "1.0.0", features = ["defmt", "esp32s3", "unstable"] }
 fugit = "0.3.9"
 gc9a01-rs = "0.4.2"

--- a/examples/screen_counter.rs
+++ b/examples/screen_counter.rs
@@ -30,6 +30,8 @@ use {defmt_rtt as _, esp_backtrace as _};
 use m5dial_bsp::bsp::*;
 extern crate alloc;
 
+esp_bootloader_esp_idf::esp_app_desc!();
+
 #[main]
 fn main() -> ! {
     // Get periferals from the hal.

--- a/examples/screen_counter_irq.rs
+++ b/examples/screen_counter_irq.rs
@@ -37,6 +37,8 @@ use core::cell::RefCell;
 use critical_section::Mutex;
 use rotary_encoder_hal::{DefaultPhase, Rotary};
 
+esp_bootloader_esp_idf::esp_app_desc!();
+
 static ENCODER: Mutex<RefCell<Option<Rotary<Input<'static>, Input<'static>, DefaultPhase>>>> =
     Mutex::new(RefCell::new(None));
 

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -22,6 +22,8 @@ use m5dial_bsp::bsp::*;
 
 extern crate alloc;
 
+esp_bootloader_esp_idf::esp_app_desc!();
+
 #[main]
 fn main() -> ! {
     // Get periferals from the hal.


### PR DESCRIPTION
See <https://github.com/esp-rs/esp-hal/releases/tag/esp-hal-v1.0.0-rc.0> migration note.