### PR TITLE
buzzer: switch to RMT peripheral from LEDC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,8 +512,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "esp-alloc"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641e43d6a60244429117ef2fa7a47182120c7561336ea01f6fb08d634f46bae1"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0db79645c7c5d1d3f1ca2f55f6520396483ea731#0db79645c7c5d1d3f1ca2f55f6520396483ea731"
 dependencies = [
  "allocator-api2",
  "cfg-if",
@@ -528,8 +527,7 @@ dependencies = [
 [[package]]
 name = "esp-backtrace"
 version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3318413fb566c7227387f67736cf70cd74d80a11f2bb31c7b95a9eb48d079669"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0db79645c7c5d1d3f1ca2f55f6520396483ea731#0db79645c7c5d1d3f1ca2f55f6520396483ea731"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",
@@ -546,8 +544,7 @@ dependencies = [
 [[package]]
 name = "esp-bootloader-esp-idf"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a56964ab5479ac20c9cf76fa3b0d3f2233b20b5d8554e81ef5d65f63c20567"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0db79645c7c5d1d3f1ca2f55f6520396483ea731#0db79645c7c5d1d3f1ca2f55f6520396483ea731"
 dependencies = [
  "cfg-if",
  "document-features",
@@ -563,8 +560,7 @@ dependencies = [
 [[package]]
 name = "esp-config"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102871054f8dd98202177b9890cb4b71d0c6fe1f1413b7a379a8e0841fc2473c"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0db79645c7c5d1d3f1ca2f55f6520396483ea731#0db79645c7c5d1d3f1ca2f55f6520396483ea731"
 dependencies = [
  "document-features",
  "esp-metadata-generated",
@@ -576,8 +572,7 @@ dependencies = [
 [[package]]
 name = "esp-hal"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54786287c0a61ca0f78cb0c338a39427551d1be229103b4444591796c579e093"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0db79645c7c5d1d3f1ca2f55f6520396483ea731#0db79645c7c5d1d3f1ca2f55f6520396483ea731"
 dependencies = [
  "bitfield",
  "bitflags 2.9.4",
@@ -632,8 +627,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-procmacros"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e025a7a7a0affdb4ff913b5c4494aef96ee03d085bf83c27453ae3a71d50da6"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0db79645c7c5d1d3f1ca2f55f6520396483ea731#0db79645c7c5d1d3f1ca2f55f6520396483ea731"
 dependencies = [
  "document-features",
  "object",
@@ -647,14 +641,12 @@ dependencies = [
 [[package]]
 name = "esp-metadata-generated"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a93e39c8ad8d390d248dc7b9f4b59a873f313bf535218b8e2351356972399e3"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0db79645c7c5d1d3f1ca2f55f6520396483ea731#0db79645c7c5d1d3f1ca2f55f6520396483ea731"
 
 [[package]]
 name = "esp-println"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a30e6c9fbcc01c348d46706fef8131c7775ab84c254a3cd65d0cd3f6414d592"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0db79645c7c5d1d3f1ca2f55f6520396483ea731#0db79645c7c5d1d3f1ca2f55f6520396483ea731"
 dependencies = [
  "document-features",
  "esp-metadata-generated",
@@ -665,8 +657,7 @@ dependencies = [
 [[package]]
 name = "esp-riscv-rt"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502744a5b1e7268d27fd2a4e56ad45efe42ead517d6c517a6961540de949b0ee"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0db79645c7c5d1d3f1ca2f55f6520396483ea731#0db79645c7c5d1d3f1ca2f55f6520396483ea731"
 dependencies = [
  "defmt 1.0.1",
  "document-features",
@@ -677,8 +668,7 @@ dependencies = [
 [[package]]
 name = "esp-rom-sys"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd66cccc6dd2d13e9f33668a57717ab14a6d217180ec112e6be533de93e7ecbf"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0db79645c7c5d1d3f1ca2f55f6520396483ea731#0db79645c7c5d1d3f1ca2f55f6520396483ea731"
 dependencies = [
  "cfg-if",
  "document-features",
@@ -688,8 +678,7 @@ dependencies = [
 [[package]]
 name = "esp-sync"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44974639b4e88914f83fe60d2832c00276657d7d857628fdfc966cc7302e8a8"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0db79645c7c5d1d3f1ca2f55f6520396483ea731#0db79645c7c5d1d3f1ca2f55f6520396483ea731"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",
@@ -1542,8 +1531,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e012d667b0aa6d2592ace8ef145a98bff3e76cca7a644f4181ecd7a916ed289b"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0db79645c7c5d1d3f1ca2f55f6520396483ea731#0db79645c7c5d1d3f1ca2f55f6520396483ea731"
 dependencies = [
  "critical-section",
 ]
@@ -1551,8 +1539,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx-rt"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8709f037fb123fe7ff146d2bce86f9dc0dfc53045c016bfd9d703317b6502845"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0db79645c7c5d1d3f1ca2f55f6520396483ea731#0db79645c7c5d1d3f1ca2f55f6520396483ea731"
 dependencies = [
  "defmt 1.0.1",
  "document-features",
@@ -1563,8 +1550,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx-rt-proc-macros"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fb42cd29c42f8744c74276e9f5bee7b06685bbe5b88df891516d72cb320450"
+source = "git+https://github.com/esp-rs/esp-hal.git?rev=0db79645c7c5d1d3f1ca2f55f6520396483ea731#0db79645c7c5d1d3f1ca2f55f6520396483ea731"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ defmt-rtt = "0.4.2"
 embedded-graphics = "0.8.1"
 embedded-hal = "1.0.0"
 embedded-hal-bus = "0.3.0"
-esp-alloc = { version = "0.9.0" }
-esp-backtrace = { version = "0.18.1", features = [
+esp-alloc = { git = "https://github.com/esp-rs/esp-hal.git", rev = "0db79645c7c5d1d3f1ca2f55f6520396483ea731" }
+esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "0db79645c7c5d1d3f1ca2f55f6520396483ea731", features = [
     "defmt",
     "esp32s3",
     "panic-handler",
 ] }
-esp-bootloader-esp-idf = { version = "0.4.0", features = ["esp32s3"] }
-esp-hal = { version = "1.0.0", features = ["defmt", "esp32s3", "unstable"] }
+esp-bootloader-esp-idf = { git = "https://github.com/esp-rs/esp-hal.git", rev = "0db79645c7c5d1d3f1ca2f55f6520396483ea731", features = ["esp32s3"] }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "0db79645c7c5d1d3f1ca2f55f6520396483ea731", features = ["defmt", "esp32s3", "unstable"] }
 fugit = "0.3.9"
 gc9a01-rs = "0.4.2"
 heapless = "0.9.2"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Feature list/roadmap:
  - [X] Button
  - [X] Power management (Shutdown)
  - [X] Touch-screen (FT3267)
- - [ ] Buzzer
+ - [X] Buzzer
  - [ ] Real-time clock (BM8563)
  - [X] Port A (I2C)
  - [X] Port B

--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -11,7 +11,7 @@ pub use esp_hal::{
     delay::Delay,
     gpio::{Input, InputConfig, Level, Output, OutputConfig, OutputPin, Pull},
     i2c::master::{Config as I2cConfig, I2c as EspI2C},
-    ledc::Ledc,
+    rmt::Rmt,
     spi::{
         master::{Config as SpiConfig, Spi},
         Mode,
@@ -175,7 +175,10 @@ macro_rules! get_port_b_out {
 #[macro_export]
 macro_rules! get_buzzer {
     ($peripherals:ident) => {
-        Buzzer::new(Ledc::new($peripherals.LEDC), $peripherals.GPIO3.into())
+        Buzzer::new(
+            Rmt::new($peripherals.RMT, Rate::from_mhz(80)).unwrap(),
+            $peripherals.GPIO3.into(),
+        )
     };
 }
 

--- a/src/buzzer.rs
+++ b/src/buzzer.rs
@@ -1,63 +1,90 @@
+use core::result::Result::{Err, Ok};
+
 // ESP32 Hardware abstraction
 use esp_hal::{
-    gpio::{AnyPin, DriveMode},
-    ledc::{
-        channel::{self, Channel, ChannelIFace},
-        timer::{self, Timer, TimerIFace},
-        LSGlobalClkSource, Ledc, LowSpeed,
-    },
-    time::Rate,
+    gpio::{AnyPin, Level},
+    rmt::{Channel, ContinuousTxTransaction, LoopMode, PulseCode, Rmt, Tx, TxChannelConfig, TxChannelCreator},
+    Blocking,
 };
+use defmt::{error};
 
-/// Buzzer driver using LEDC peripheral to generate the PWM signal.
-pub struct Buzzer<'t> {
-    timer: Timer<'t, LowSpeed>,
-    channel: Channel<'t, LowSpeed>,
+const ESP32S3_RMT_DEFAULT_CLK_FREQ_HZ: u32 = 80_000_000;
+const ESP32S3_RMT_MAX_TX_LOOP_NUM: u32 = 1023; // see ESP32S3 PAC: register is 10 bits wide
+const CLK_FREQ_HZ: u32 = 3_200_000;
+const PULSE_COUNT: usize = 1;
+
+#[derive(Debug)]
+pub enum Error {
+    FreqTooLow(u16),
+    DurationTooLongForFreq((u16, u16)),
+    StopError(esp_hal::rmt::Error),
+    TxError(esp_hal::rmt::Error),
 }
 
-impl<'t> Buzzer<'t> {
+#[derive(Debug)]
+enum Resource<'b> {
+    Channel(Channel<'b, Blocking, Tx>),
+    ContinuousTx(ContinuousTxTransaction<'b>),
+}
+
+/// Buzzer driver using RMT peripheral to generate the signal.
+#[derive(Debug)]
+pub struct Buzzer<'b> {
+    buf: [PulseCode; PULSE_COUNT + 1], // end marker required
+    resource: Resource<'b>,
+}
+
+impl<'b> Buzzer<'b> {
     /// Build a new buzzer driver.
     ///
-    /// This required a LEDC peripheral driver `ledc` and the output `pin`
-    pub fn new(mut ledc: Ledc<'t>, pin: AnyPin<'t>) -> Self {
-        // Initialize and create handle for LEDC peripheral
-        //let mut ledc = Ledc::new(led_perif);
-        ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
-
-        let channel = ledc.channel(channel::Number::Channel0, pin);
-        let timer = ledc.timer::<LowSpeed>(timer::Number::Timer0);
-        Buzzer { timer, channel }
+    /// This requires an RMT peripheral driver `rmt` and the output `pin`
+    pub fn new(rmt: Rmt<'b, Blocking>, pin: AnyPin<'b>) -> Self {
+        let channel = rmt
+            .channel0
+            .configure_tx(&TxChannelConfig::default()
+                          .with_clk_divider((ESP32S3_RMT_DEFAULT_CLK_FREQ_HZ / CLK_FREQ_HZ).try_into().unwrap())
+                          .with_idle_output_level(Level::Low)
+                          .with_idle_output(false)
+                          .with_carrier_modulation(false)
+                          .with_carrier_high(1)
+                          .with_carrier_low(1)
+                          .with_carrier_level(Level::Low)
+            ).expect("RMT channel0 could not configure")
+            .with_pin(pin);
+        Buzzer { buf: [PulseCode::default(), PulseCode::end_marker()], resource: Resource::Channel(channel) }
     }
 
-    // Private function to do the actual PWM frequency and duty settings.
-    fn configure(&'t mut self, freq: Rate, duty: u8) {
-        //let mut timer = self.ledc.timer::<LowSpeed>(timer::Number::Timer0);
-        //let mut channel = self.ledc.channel(channel::Number::Channel0, self.pin);
+    pub fn tone(mut self, freq_hz: u16, duration_ms: u16) -> Result<Self, (Self, Error)> {
+        if freq_hz as u32 <= CLK_FREQ_HZ / (1 << 16) {
+            // 50% duty on 15 bits is 16 bits for a single PulseCode -> ~49 Hz
+            return Err((self, Error::FreqTooLow(freq_hz)));
+        }
 
-        self.timer
-            .configure(timer::config::Config {
-                duty: timer::config::Duty::Duty5Bit,
-                clock_source: timer::LSClockSource::APBClk,
-                frequency: freq,
-            })
-            .unwrap();
+        let wave_length = CLK_FREQ_HZ / (freq_hz as u32); // range checked by freq_hz
+        let count_u32 = (duration_ms as u32 * freq_hz as u32) / 1000;
+        let count = if count_u32 > ESP32S3_RMT_MAX_TX_LOOP_NUM {
+            return Err((self, Error::DurationTooLongForFreq((duration_ms, freq_hz))));
+        } else {
+            count_u32 as u16
+        };
 
-        self.channel
-            .configure(channel::config::Config {
-                timer: &self.timer,
-                duty_pct: duty,
-                drive_mode: DriveMode::PushPull,
-            })
-            .unwrap();
-    }
+        let high = (wave_length / 2) as u16;
+        let low = (wave_length - high as u32) as u16;
+        self.buf[0] = PulseCode::new(Level::High, high, Level::Low, low);
 
-    /// Set buzzing frequency, in Hz
-    pub fn set_frequency(&'t mut self, freq: Rate) {
-        self.configure(freq, 50);
-    }
-
-    /// Turn the buzzer OFF
-    pub fn off(&'t mut self) {
-        self.configure(Rate::from_hz(1000), 0);
+        let ch = match self.resource {
+            Resource::ContinuousTx(txn) => match txn.stop() {
+                Ok(ch) => ch,
+                Err((e, ch)) => return Err((Buzzer { buf: self.buf, resource: Resource::Channel(ch)}, Error::StopError(e))),
+            },
+            Resource::Channel(ch) => ch,
+        };
+        match ch.transmit_continuously(&self.buf, LoopMode::Finite(count)) {
+            Ok(txn) => Ok(Buzzer { buf: self.buf, resource: Resource::ContinuousTx(txn) }),
+            Err((e, ch)) => {
+                error!("count = {}", count);
+                Err((Buzzer { buf: self.buf, resource: Resource::Channel(ch) }, Error::TxError(e)))
+            },
+        }
     }
 }


### PR DESCRIPTION
RMT lets us load buffers to playout asynchronously in hardware and features looping and interruption.

buzzer module now contains a very basic 1-bit synth that could be significantly expanded through fx, improved error handling, wider synthesis ranges, etc.

The screen counter demos are very slightly buggy in that very low frequencies can saturate at zero. The non-IRQ demo also seems to output spurious clicks for some reason.

A built-out synth doesn't really belong in this crate, I think, but this seems like a reasonable place to incubate it. Possible next steps are note values, chirps, multiple pulse code handling for very low and very high frequencies, indefinite tones with stop function, etc.

Let me know if you'd like modifications or if you think you'd rather not adopt this approach and I will be happy to oblige.

Thanks!