### PR TITLE
Error mgmt

### DIFF
--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -299,15 +299,17 @@ fn main() -> ! {
 
         if clock.is_running() {
             // Get the RTC time and update the Clock APP
-            let now = rtc.get_time(&mut tp_i2c);
-            clock.update_from(&now);
+            if let Ok(now) = rtc.get_time(&mut tp_i2c) {
+                clock.update_from(&now);
+            }
 
-            let today = rtc.get_date(&mut tp_i2c);
-            clock.update_date_from(&today);
+            if let Ok(today) = rtc.get_date(&mut tp_i2c) {
+                clock.update_date_from(&today);
+            }
         } else {
             // Get the on-screen time & Date and set the RTC
-            rtc.set_time(&mut tp_i2c, clock.get_time());
-            rtc.set_date(&mut tp_i2c, clock.get_date());
+            let _ = rtc.set_time(&mut tp_i2c, clock.get_time());
+            let _ = rtc.set_date(&mut tp_i2c, clock.get_date());
         }
 
         // Update display

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -31,7 +31,7 @@ fn main() -> ! {
     let peripherals = esp_hal::init(config);
 
     let mut tp_i2c = m5dial_bsp::get_internal_i2C!(peripherals);
-    let mut touch = m5dial_bsp::get_touch!(tp_i2c);
+    let touch = m5dial_bsp::get_touch!(tp_i2c);
     let mut display = m5dial_bsp::get_screen!(peripherals);
 
     // Initialize the BSP
@@ -69,13 +69,20 @@ fn main() -> ! {
             }
         }
 
-        if let Some(_) = touch.count(&mut tp_i2c) {
-            //info!("Touch: {}", touch_count);
-            let p = touch.get_point(&mut tp_i2c, 0);
-            info!("Pos: x={} y={}", p.x, p.y);
-            point.x = p.x.into();
-            point.y = p.y.into();
-            need_redraw = true;
+        if let Ok(x) = touch.count(&mut tp_i2c) {
+            if let Some(_) = x {
+                //info!("Touch: {}", touch_count);
+                if let Ok(p) = touch.get_point(&mut tp_i2c, 0) {
+                    info!("Pos: x={} y={}", p.x, p.y);
+                    point.x = p.x.into();
+                    point.y = p.y.into();
+                    need_redraw = true;
+                } else {
+                    error!("I2C error");
+                }
+            }
+        } else {
+            error!("I2C error");
         }
 
         if need_redraw {

--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -131,7 +131,7 @@ macro_rules! get_screen {
 macro_rules! get_touch {
     ($tp_i2c:ident) => {{
         let touch = Ft3267::new(0);
-        touch.init(&mut $tp_i2c);
+        let _ = touch.init(&mut $tp_i2c);
         touch
     }};
 }

--- a/src/ft3267/mod.rs
+++ b/src/ft3267/mod.rs
@@ -41,18 +41,27 @@ pub struct TouchPoint {
 }
 
 impl Ft3267 {
-    fn write_register<T: I2c>(&self, bus: &mut T, reg_addr: u8, reg_value: u8) {
+    fn write_register<T: I2c>(
+        &self,
+        bus: &mut T,
+        reg_addr: u8,
+        reg_value: u8,
+    ) -> Result<(), T::Error> {
         let buffer: [u8; 2] = [reg_addr, reg_value];
 
-        // TODO : Error handling
-        let _ = bus.write(self.address, &buffer);
+        bus.write(self.address, &buffer)
     }
 
-    fn read_register<T: I2c>(&self, bus: &mut T, reg_addr: u8, buffer: &mut [u8]) {
+    fn read_register<T: I2c>(
+        &self,
+        bus: &mut T,
+        reg_addr: u8,
+        buffer: &mut [u8],
+    ) -> Result<(), T::Error> {
         let addr_buffer: [u8; 1] = [reg_addr];
 
         // TODO : Error handling
-        let _ = bus.write_read(self.address, &addr_buffer, buffer);
+        bus.write_read(self.address, &addr_buffer, buffer)
     }
 
     /// Build a new FT3257 driver
@@ -66,55 +75,55 @@ impl Ft3267 {
     }
 
     /// Initialize the driver IC.
-    pub fn init<T: I2c>(&self, bus: &mut T) -> &Self {
-        self.write_register(bus, regs::FT3267_ID_G_THGROUP, 70);
+    pub fn init<T: I2c>(&self, bus: &mut T) -> Result<&Self, T::Error> {
+        self.write_register(bus, regs::FT3267_ID_G_THGROUP, 70)?;
 
         // valid touching peak detect threshold
-        self.write_register(bus, regs::FT3267_ID_G_THPEAK, 60);
+        self.write_register(bus, regs::FT3267_ID_G_THPEAK, 60)?;
 
         // Touch focus threshold
-        self.write_register(bus, regs::FT3267_ID_G_THCAL, 16);
+        self.write_register(bus, regs::FT3267_ID_G_THCAL, 16)?;
 
         // threshold when there is surface water
-        self.write_register(bus, regs::FT3267_ID_G_THWATER, 60);
+        self.write_register(bus, regs::FT3267_ID_G_THWATER, 60)?;
 
         // threshold of temperature compensation
-        self.write_register(bus, regs::FT3267_ID_G_THTEMP, 10);
+        self.write_register(bus, regs::FT3267_ID_G_THTEMP, 10)?;
 
         // Touch difference threshold
-        self.write_register(bus, regs::FT3267_ID_G_THDIFF, 20);
+        self.write_register(bus, regs::FT3267_ID_G_THDIFF, 20)?;
 
         // Delay to enter 'Monitor' status (s)
-        self.write_register(bus, regs::FT3267_ID_G_TIME_ENTER_MONITOR, 2);
+        self.write_register(bus, regs::FT3267_ID_G_TIME_ENTER_MONITOR, 2)?;
 
         // Period of 'Active' status (ms)
-        self.write_register(bus, regs::FT3267_ID_G_PERIODACTIVE, 12);
+        self.write_register(bus, regs::FT3267_ID_G_PERIODACTIVE, 12)?;
 
         // Timer to enter 'idle' when in 'Monitor' (ms)
-        self.write_register(bus, regs::FT3267_ID_G_PERIODMONITOR, 40);
+        self.write_register(bus, regs::FT3267_ID_G_PERIODMONITOR, 40)?;
 
-        self
+        Ok(self)
     }
 
     /// Pool if the touch screen is touched.
     ///
     /// Returns the number of current touch points.
-    pub fn pool<T: I2c>(&self, bus: &mut T) -> u8 {
+    pub fn pool<T: I2c>(&self, bus: &mut T) -> Result<u8, T::Error> {
         let mut raw_data: [u8; 1] = [0];
-        self.read_register(bus, regs::FT3267_TOUCH_POINTS, &mut raw_data);
-        raw_data[0] & 0x0f
+        self.read_register(bus, regs::FT3267_TOUCH_POINTS, &mut raw_data)?;
+        Ok(raw_data[0] & 0x0f)
     }
 
     /// Query if the touch screen is touched. If touch screen
     /// is un-touched, return None. Return Some() with detected
     /// finger count if touched (supports multi-touch).
-    pub fn count<T: I2c>(&self, bus: &mut T) -> Option<u8> {
-        let touch_count = self.pool(bus);
+    pub fn count<T: I2c>(&self, bus: &mut T) -> Result<Option<u8>, T::Error> {
+        let touch_count = self.pool(bus)?;
 
         if touch_count > 0 {
-            Some(touch_count)
+            Ok(Some(touch_count))
         } else {
-            None
+            Ok(None)
         }
     }
 
@@ -122,21 +131,21 @@ impl Ft3267 {
     ///
     /// n touch point index.
     /// return touch point coordinate.
-    pub fn get_point<T: I2c>(&self, bus: &mut T, n: u8) -> TouchPoint {
+    pub fn get_point<T: I2c>(&self, bus: &mut T, n: u8) -> Result<TouchPoint, T::Error> {
         let mut buf: [u8; 4] = [0; 4];
 
         match n {
             0 => {
-                self.read_register(bus, regs::FT3267_TOUCH1_XH, &mut buf);
+                self.read_register(bus, regs::FT3267_TOUCH1_XH, &mut buf)?;
             }
             1 => {
-                self.read_register(bus, regs::FT3267_TOUCH2_XH, &mut buf);
+                self.read_register(bus, regs::FT3267_TOUCH2_XH, &mut buf)?;
             }
             2 => {
-                self.read_register(bus, regs::FT3267_TOUCH3_XH, &mut buf);
+                self.read_register(bus, regs::FT3267_TOUCH3_XH, &mut buf)?;
             }
             3 => {
-                self.read_register(bus, regs::FT3267_TOUCH4_XH, &mut buf);
+                self.read_register(bus, regs::FT3267_TOUCH4_XH, &mut buf)?;
             }
             _ => {}
         }
@@ -144,10 +153,11 @@ impl Ft3267 {
         let x = (((buf[0] & 0x0f) as u16) << 8) + buf[1] as u16;
         let y = (((buf[2] & 0x0f) as u16) << 8) + buf[3] as u16;
 
-        if self.rotation == 0 {
+        let coord = if self.rotation == 0 {
             TouchPoint { id: n, x, y }
         } else {
             TouchPoint { id: n, x: y, y: x }
-        }
+        };
+        Ok(coord)
     }
 }

--- a/src/ft3267/mod.rs
+++ b/src/ft3267/mod.rs
@@ -41,23 +41,23 @@ pub struct TouchPoint {
 }
 
 impl Ft3267 {
-    fn write_register<T: I2c>(
+    fn write_register<I2C: I2c>(
         &self,
-        bus: &mut T,
+        bus: &mut I2C,
         reg_addr: u8,
         reg_value: u8,
-    ) -> Result<(), T::Error> {
+    ) -> Result<(), I2C::Error> {
         let buffer: [u8; 2] = [reg_addr, reg_value];
 
         bus.write(self.address, &buffer)
     }
 
-    fn read_register<T: I2c>(
+    fn read_register<I2C: I2c>(
         &self,
-        bus: &mut T,
+        bus: &mut I2C,
         reg_addr: u8,
         buffer: &mut [u8],
-    ) -> Result<(), T::Error> {
+    ) -> Result<(), I2C::Error> {
         let addr_buffer: [u8; 1] = [reg_addr];
 
         // TODO : Error handling
@@ -75,7 +75,7 @@ impl Ft3267 {
     }
 
     /// Initialize the driver IC.
-    pub fn init<T: I2c>(&self, bus: &mut T) -> Result<&Self, T::Error> {
+    pub fn init<I2C: I2c>(&self, bus: &mut I2C) -> Result<&Self, I2C::Error> {
         self.write_register(bus, regs::FT3267_ID_G_THGROUP, 70)?;
 
         // valid touching peak detect threshold
@@ -108,7 +108,7 @@ impl Ft3267 {
     /// Pool if the touch screen is touched.
     ///
     /// Returns the number of current touch points.
-    pub fn pool<T: I2c>(&self, bus: &mut T) -> Result<u8, T::Error> {
+    pub fn pool<I2C: I2c>(&self, bus: &mut I2C) -> Result<u8, I2C::Error> {
         let mut raw_data: [u8; 1] = [0];
         self.read_register(bus, regs::FT3267_TOUCH_POINTS, &mut raw_data)?;
         Ok(raw_data[0] & 0x0f)
@@ -117,7 +117,7 @@ impl Ft3267 {
     /// Query if the touch screen is touched. If touch screen
     /// is un-touched, return None. Return Some() with detected
     /// finger count if touched (supports multi-touch).
-    pub fn count<T: I2c>(&self, bus: &mut T) -> Result<Option<u8>, T::Error> {
+    pub fn count<I2C: I2c>(&self, bus: &mut I2C) -> Result<Option<u8>, I2C::Error> {
         let touch_count = self.pool(bus)?;
 
         if touch_count > 0 {
@@ -131,7 +131,7 @@ impl Ft3267 {
     ///
     /// n touch point index.
     /// return touch point coordinate.
-    pub fn get_point<T: I2c>(&self, bus: &mut T, n: u8) -> Result<TouchPoint, T::Error> {
+    pub fn get_point<I2C: I2c>(&self, bus: &mut I2C, n: u8) -> Result<TouchPoint, I2C::Error> {
         let mut buf: [u8; 4] = [0; 4];
 
         match n {

--- a/src/rtc8563/mod.rs
+++ b/src/rtc8563/mod.rs
@@ -2,16 +2,16 @@
 //!
 //! Mainly ported to Rust from this repo: https://github.com/tanakamasayuki/I2C_BM8563
 
-use embedded_hal::{i2c::I2c, spi::Error};
+use embedded_hal::i2c::I2c;
 
 pub const RTC8563_DEFAULT_I2C_ADDRESS: u8 = 0x51;
 
 const SECONDS_REG: u8 = 0x02;
-//const MINTES_REG: u8 = 0x03;
+//const MINI2CES_REG: u8 = 0x03;
 //const HOURS_REG: u8 = 0x04;
 const DAYS_REG: u8 = 0x05;
 //const WEEKDAY_REG: u8 = 0x06;
-//const MONTHS_REG: u8 = 0x07;
+//const MONI2CHS_REG: u8 = 0x07;
 //const YEAR_REG: u8 = 0x08;
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -61,13 +61,13 @@ impl Rtc8563 {
 
     /// Initialize chip.
     ///
-    /// This clear Control/status 1 and 2.
-    pub fn init<T: I2c>(&self, bus: &mut T) -> Result<(), T::Error> {
+    /// I2Chis clear Control/status 1 and 2.
+    pub fn init<I2C: I2c>(&self, bus: &mut I2C) -> Result<(), I2C::Error> {
         let buffer: [u8; 3] = [0, 0, 0];
         bus.write(self.address, &buffer)
     }
 
-    pub fn get_time<T: I2c>(&self, bus: &mut T) -> Result<Time, T::Error> {
+    pub fn get_time<I2C: I2c>(&self, bus: &mut I2C) -> Result<Time, I2C::Error> {
         let addr_buffer: [u8; 1] = [SECONDS_REG];
         let mut buffer: [u8; 3] = [0, 0, 0];
 
@@ -80,7 +80,7 @@ impl Rtc8563 {
         })
     }
 
-    pub fn set_time<T: I2c>(&self, bus: &mut T, time: &Time) -> Result<(), T::Error> {
+    pub fn set_time<I2C: I2c>(&self, bus: &mut I2C, time: &Time) -> Result<(), I2C::Error> {
         let buffer: [u8; 4] = [
             SECONDS_REG,
             byte2bcd(time.seconds),
@@ -91,7 +91,7 @@ impl Rtc8563 {
         bus.write(self.address, &buffer)
     }
 
-    pub fn get_date<T: I2c>(&self, bus: &mut T) -> Result<Date, T::Error> {
+    pub fn get_date<I2C: I2c>(&self, bus: &mut I2C) -> Result<Date, I2C::Error> {
         let addr_buffer: [u8; 1] = [DAYS_REG];
         let mut buffer: [u8; 4] = [0; 4];
 
@@ -109,7 +109,7 @@ impl Rtc8563 {
         })
     }
 
-    pub fn set_date<T: I2c>(&self, bus: &mut T, date: &Date) -> Result<(), T::Error> {
+    pub fn set_date<I2C: I2c>(&self, bus: &mut I2C, date: &Date) -> Result<(), I2C::Error> {
         let mut buffer: [u8; 5] = [DAYS_REG, 0, 0, 0, 0];
         buffer[1] = byte2bcd(date.day) & 0x3f;
         buffer[2] = byte2bcd(date.week_day) & 0x0f;
@@ -124,19 +124,19 @@ impl Rtc8563 {
     }
 
     #[allow(dead_code)]
-    fn write_register<T: I2c>(
+    fn write_register<I2C: I2c>(
         &self,
-        bus: &mut T,
+        bus: &mut I2C,
         reg_addr: u8,
         reg_value: u8,
-    ) -> Result<(), T::Error> {
+    ) -> Result<(), I2C::Error> {
         let buffer: [u8; 2] = [reg_addr, reg_value];
 
         bus.write(self.address, &buffer)
     }
 
     #[allow(dead_code)]
-    fn read_register<T: I2c>(&self, bus: &mut T, reg_addr: u8) -> Result<u8, T::Error> {
+    fn read_register<I2C: I2c>(&self, bus: &mut I2C, reg_addr: u8) -> Result<u8, I2C::Error> {
         let addr_buffer: [u8; 1] = [reg_addr];
         let mut buffer: [u8; 1] = [0];
 

--- a/src/rtc8563/mod.rs
+++ b/src/rtc8563/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Mainly ported to Rust from this repo: https://github.com/tanakamasayuki/I2C_BM8563
 
-use embedded_hal::i2c::I2c;
+use embedded_hal::{i2c::I2c, spi::Error};
 
 pub const RTC8563_DEFAULT_I2C_ADDRESS: u8 = 0x51;
 
@@ -62,26 +62,25 @@ impl Rtc8563 {
     /// Initialize chip.
     ///
     /// This clear Control/status 1 and 2.
-    pub fn init<T: I2c>(&self, bus: &mut T) {
+    pub fn init<T: I2c>(&self, bus: &mut T) -> Result<(), T::Error> {
         let buffer: [u8; 3] = [0, 0, 0];
-        bus.write(self.address, &buffer).expect("I2C write error");
+        bus.write(self.address, &buffer)
     }
 
-    pub fn get_time<T: I2c>(&self, bus: &mut T) -> Time {
+    pub fn get_time<T: I2c>(&self, bus: &mut T) -> Result<Time, T::Error> {
         let addr_buffer: [u8; 1] = [SECONDS_REG];
         let mut buffer: [u8; 3] = [0, 0, 0];
 
-        bus.write_read(self.address, &addr_buffer, &mut buffer)
-            .expect("I2C read error");
+        bus.write_read(self.address, &addr_buffer, &mut buffer)?;
 
-        Time {
+        Ok(Time {
             hours: bcd2byte(buffer[2] & 0x3F),
             minutes: bcd2byte(buffer[1] & 0x7F),
             seconds: bcd2byte(buffer[0] & 0x7F),
-        }
+        })
     }
 
-    pub fn set_time<T: I2c>(&self, bus: &mut T, time: &Time) {
+    pub fn set_time<T: I2c>(&self, bus: &mut T, time: &Time) -> Result<(), T::Error> {
         let buffer: [u8; 4] = [
             SECONDS_REG,
             byte2bcd(time.seconds),
@@ -89,17 +88,16 @@ impl Rtc8563 {
             byte2bcd(time.hours),
         ];
 
-        bus.write(self.address, &buffer).expect("I2C write error");
+        bus.write(self.address, &buffer)
     }
 
-    pub fn get_date<T: I2c>(&self, bus: &mut T) -> Date {
+    pub fn get_date<T: I2c>(&self, bus: &mut T) -> Result<Date, T::Error> {
         let addr_buffer: [u8; 1] = [DAYS_REG];
         let mut buffer: [u8; 4] = [0; 4];
 
-        bus.write_read(self.address, &addr_buffer, &mut buffer)
-            .expect("I2C read error");
+        bus.write_read(self.address, &addr_buffer, &mut buffer)?;
 
-        Date {
+        Ok(Date {
             day: bcd2byte(buffer[0] & 0x3f),
             week_day: bcd2byte(buffer[1] & 0x0f),
             month: bcd2byte(buffer[2] & 0x1f),
@@ -108,10 +106,10 @@ impl Rtc8563 {
             } else {
                 2000 + bcd2byte(buffer[3]) as i16
             },
-        }
+        })
     }
 
-    pub fn set_date<T: I2c>(&self, bus: &mut T, date: &Date) {
+    pub fn set_date<T: I2c>(&self, bus: &mut T, date: &Date) -> Result<(), T::Error> {
         let mut buffer: [u8; 5] = [DAYS_REG, 0, 0, 0, 0];
         buffer[1] = byte2bcd(date.day) & 0x3f;
         buffer[2] = byte2bcd(date.week_day) & 0x0f;
@@ -122,25 +120,28 @@ impl Rtc8563 {
         }
         buffer[4] = byte2bcd((date.year % 100) as u8);
 
-        bus.write(self.address, &buffer).expect("I2C write failed");
+        bus.write(self.address, &buffer)
     }
 
     #[allow(dead_code)]
-    fn write_register<T: I2c>(&self, bus: &mut T, reg_addr: u8, reg_value: u8) {
+    fn write_register<T: I2c>(
+        &self,
+        bus: &mut T,
+        reg_addr: u8,
+        reg_value: u8,
+    ) -> Result<(), T::Error> {
         let buffer: [u8; 2] = [reg_addr, reg_value];
 
-        // TODO : Error handling
-        let _ = bus.write(self.address, &buffer);
+        bus.write(self.address, &buffer)
     }
 
     #[allow(dead_code)]
-    fn read_register<T: I2c>(&self, bus: &mut T, reg_addr: u8) -> u8 {
+    fn read_register<T: I2c>(&self, bus: &mut T, reg_addr: u8) -> Result<u8, T::Error> {
         let addr_buffer: [u8; 1] = [reg_addr];
         let mut buffer: [u8; 1] = [0];
 
-        // TODO : Error handling
-        let _ = bus.write_read(self.address, &addr_buffer, &mut buffer);
+        bus.write_read(self.address, &addr_buffer, &mut buffer)?;
 
-        buffer[0]
+        Ok(buffer[0])
     }
 }


### PR DESCRIPTION
This PR enables the library to propagate the errors to the callers. Removes some ".expect()".